### PR TITLE
application_wpe start up in Preloading state.

### DIFF
--- a/src/third_party/starboard/wpe/shared/application_wpe.cc
+++ b/src/third_party/starboard/wpe/shared/application_wpe.cc
@@ -167,6 +167,16 @@ void Application::Inject(Event* e) {
   QueueApplication::Inject(e);
 }
 
+bool Application::IsStartImmediate()
+{
+  return false;
+}
+
+bool Application::IsPreloadImmediate()
+{
+  return true;
+}
+
 }  // namespace shared
 }  // namespace wpe
 }  // namespace starboard

--- a/src/third_party/starboard/wpe/shared/application_wpe.h
+++ b/src/third_party/starboard/wpe/shared/application_wpe.h
@@ -57,6 +57,8 @@ class Application : public ::starboard::shared::starboard::QueueApplication {
   void OnSuspend() override;
   void OnResume() override;
   void Inject(Event* e) override;
+  bool IsStartImmediate() override;
+  bool IsPreloadImmediate() override;
 
   // --- QueueApplication overrides ---
   bool MayHaveSystemEvents() override;


### PR DESCRIPTION
Fixes issue reported by MCA with blank screen observed on Cobalt activation.
Changed start up from Starting state to Preloading state to avoid initializing
resources and immediately deinitializing due to going straight to suspend mode.
Like in Starting state application is running but in Preloading state is not visible and receive no input.